### PR TITLE
Define Patch_somegame in GBApatch.h

### DIFF
--- a/source/GBApatch.h
+++ b/source/GBApatch.h
@@ -75,4 +75,5 @@ u32 Find_spend_address_SpecialROM(u32* Data);
 void Patch_SpecialROM_TrimSize(void);
 u32 Check_game_RTS_FAT(TCHAR *filename,u32 game_save_rts);
 void IWRAM_CODE PatchInternal(u32* Data,int iSize,u32 offset);
+void Patch_somegame(u32 *Data);
 void Patch_SpecialROM_sleepmode(void);


### PR DESCRIPTION
Without this, building on Windows (only platform I tested) doesn't work