### PR TITLE
Feat/build and safety cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# IDE
+.idea/
+*.iml
+*.iws
+*.ipr
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Primary Output
+build/
+*.elf
+*.gba
+
+# Intermediate files (Object files, Linker output)
+*.o
+*.o.d
+*.d
+*.map
+*.sym
+*.a
+*.lib

--- a/source/GBApatch.h
+++ b/source/GBApatch.h
@@ -75,4 +75,5 @@ u32 Find_spend_address_SpecialROM(u32* Data);
 void Patch_SpecialROM_TrimSize(void);
 u32 Check_game_RTS_FAT(TCHAR *filename,u32 game_save_rts);
 void IWRAM_CODE PatchInternal(u32* Data,int iSize,u32 offset);
+void Patch_somegame(u32 *Data);
 void Patch_SpecialROM_sleepmode(void);

--- a/source/NORflash_OP.c
+++ b/source/NORflash_OP.c
@@ -273,9 +273,8 @@ u32 Loadfile2NOR(TCHAR *filename, u32 NORaddress,u16 have_patch,u8 SAVEMODE)
 		*((vu16 *)(FlashBase_S98+0x000*2)) = 0x30 ;
 		{
 			int polling_counter = 0x15000;
-			u16 v1;
 			do {
-				v1 = *((vu16 *)(FlashBase_S98+ 0x5C0000));
+				(void)*((vu16 *)(FlashBase_S98+ 0x5C0000)); // Volatile read for polling; discard result
 				polling_counter--;
 
 			} while (polling_counter);

--- a/source/draw.c
+++ b/source/draw.c
@@ -6,7 +6,7 @@
 #include <string.h>
 
 #include "ez_define.h"
-#include "hzk12.h"
+#include "HZK12.h"
 #include "asc126.h"
 #include "ezkernel.h"
 #include "draw.h"

--- a/source/ezkernelnew.c
+++ b/source/ezkernelnew.c
@@ -1309,7 +1309,7 @@ void CheckLanguage(void)
 	{
 		LoadEnglish();
 	}
-	else//жпнд
+	else//О©╫О©╫О©╫О©╫
 	{
 		LoadChinese();
 	}
@@ -2319,12 +2319,16 @@ re_showfile:
 			{
 				if(page_num==SD_list){
 					//res = f_getcwd(currentpath, sizeof currentpath / sizeof *currentpath);		
-		      if( show_offset+file_select <  folder_total)
-		      {	   				
-	   				if(strcmp(currentpath,"/") !=0){	
-	   					sprintf(currentpath,"%s%s",currentpath,"/");
+		      		if( show_offset+file_select <  folder_total)
+		      		{	   				
+						if(strcmp(currentpath,"/") !=0){	
+							size_t len = strlen(currentpath);
+							if (len < MAX_path_len - 1) { // Space for '/' and Null-Terminator
+								currentpath[len] = '/';
+								currentpath[len + 1] = 0;
+							}
 						}
-		      	sprintf(currentpath,"%s%s",currentpath,pFolder[show_offset+file_select].filename);
+						strncat(currentpath, pFolder[show_offset+file_select].filename, MAX_path_len - strlen(currentpath) - 1);
 		      	
 						res=f_chdir(currentpath);
 						if(res != FR_OK){


### PR DESCRIPTION
This Pull Request bundles essential maintenance, code safety fixes, and structural improvements to enhance the repository's reliability and developer experience.

It consists of two logically separate commits:

1. Code Security and Quality Fixes (fix(...))
2. Repository Configuration (feat(...))

### 1. Code Security & Quality (Focus: Fixing Warnings/Vulnerabilities)

This addresses issues identified during the build process, preventing potential runtime bugs (buffer overflows) and improving code compilation:

- Critical Safety Fix (Path Manipulation): Replaced unsafe sprintf() calls for directory path construction (currentpath) in ezkernelnew.c with secure methods (strncat and manual handling). This resolves warnings concerning buffer overflow and overlapping source/destination arguments.
- Compiler Cleanup: Resolved the "variable set but not used" warning in NORflash_OP.c by removing the unused variable and maintaining the volatile read using (void) casting.
- Structural/Build Fixes: Corrected the case sensitivity of a header include (draw.c) and added a missing function prototype to GBApatch.h.

### 2. Repository Configuration (Developer Experience)

- .gitignore Addition: Introduces a comprehensive .gitignore file to permanently exclude common build artifacts, linker output (*.o, *.map, *.gba), and IDE/OS-specific metadata files (.idea/, .vscode/, .DS_Store). This ensures a cleaner working directory and Git history for all contributors.